### PR TITLE
feat: cache plantuml diagrams

### DIFF
--- a/options.html
+++ b/options.html
@@ -160,6 +160,10 @@
             <option value="svg">SVG (vector)</option>
             <option value="png">PNG (bitmap)</option>
           </select>
+
+          <button id="clearCacheButton" class="button" type="button">
+            Clear Diagram Cache
+          </button>
         </div>
       </div>
 

--- a/options.js
+++ b/options.js
@@ -29,6 +29,7 @@ const customApiResponseFieldInput = document.getElementById('customApiResponseFi
 // DOM Elements - Buttons
 const saveButton = document.getElementById('saveButton');
 const resetButton = document.getElementById('resetButton');
+const clearCacheButton = document.getElementById('clearCacheButton');
 
 // Default Advanced Settings
 const DEFAULT_ADVANCED_SETTINGS = {
@@ -219,4 +220,14 @@ document.addEventListener('DOMContentLoaded', () => {
     setupTabs();
 });
 saveButton.addEventListener('click', saveAdvancedSettings);
-resetButton.addEventListener('click', resetSettings); 
+resetButton.addEventListener('click', resetSettings);
+clearCacheButton?.addEventListener('click', () => {
+    chrome.tabs.query({}, (tabs) => {
+        tabs.forEach(tab => {
+            chrome.tabs.sendMessage(tab.id, { action: 'clearCache' }).catch(() => {
+                // Ignore errors for inactive tabs
+            });
+        });
+    });
+    showMessage('Diagram cache cleared', 'success');
+});


### PR DESCRIPTION
## Summary
- cache PlantUML diagram images by encoded UML to avoid redundant server requests
- add option page control to manually clear cached diagrams

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token static)*
- `npm test` *(fails: jest: not found)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689f922fde6483209c0bd34ac94dfb57